### PR TITLE
use updated .obj files and new Drake layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 deps/Valkyrie
+deps/valkyrie

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,5 @@
-datadir = "Valkyrie"
-valkyrie_examples_url = "https://raw.githubusercontent.com/RobotLocomotion/drake/6e3ca768cbaabf15d0f2bed0fb5bd703fa022aa5/drake/examples/Valkyrie/"
+datadir = "valkyrie"
+valkyrie_examples_url = "https://raw.githubusercontent.com/rdeits/drake/eb1dc0ff1b263772e26e177566479c9d17571e7d/examples/valkyrie/"
 urdfpath = "urdf/urdf/valkyrie_A_sim_drake_one_neck_dof_wide_ankle_rom.urdf"
 meshpaths = ["urdf/model/meshes/arms/aj1_left.obj";
     "urdf/model/meshes/arms/aj1_right.obj";

--- a/src/ValkyrieRobot.jl
+++ b/src/ValkyrieRobot.jl
@@ -12,7 +12,7 @@ include("bipedcontrolutil.jl")
 using .BipedControlUtil
 
 packagepath() = Pkg.dir("ValkyrieRobot", "deps")
-urdfpath() = joinpath(packagepath(), "Valkyrie", "valkyrie.urdf")
+urdfpath() = joinpath(packagepath(), "valkyrie", "valkyrie.urdf")
 
 function default_contact_model()
     SoftContactModel(hunt_crossley_hertz(k = 500e3), ViscoelasticCoulombModel(0.8, 20e3, 100.))


### PR DESCRIPTION
The new .obj files aren't in Drake master yet, but they're available on my fork. This also changes the deps directory a bit to account for the fact that `drake/examples/Valkyrie` is now `examples/valkyrie` in Drake. 