### PR TITLE
Fixes for 0.7. Currently doesn't work yet because of FileIO.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.jl.mem
 deps/Valkyrie
 deps/valkyrie
+deps/build.log
+

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 julia 0.6
 RigidBodyDynamics 0.3.0
+Compat 0.47.0 # for Random
+StaticArrays

--- a/src/ValkyrieRobot.jl
+++ b/src/ValkyrieRobot.jl
@@ -78,4 +78,11 @@ end
 
 Valkyrie(::Type{T} = Float64; kwargs...) where {T} = Valkyrie{T}(; kwargs...)
 
+
+function __init__()
+    if !isfile(urdfpath())
+        error("Could not find $(urdfpath()). Please run `Pkg.build(\"ValkyrieRobot\")`.")
+    end
+end
+
 end # module

--- a/src/ValkyrieRobot.jl
+++ b/src/ValkyrieRobot.jl
@@ -1,5 +1,6 @@
 module ValkyrieRobot
 
+using Compat
 using RigidBodyDynamics
 using RigidBodyDynamics.Contact
 using StaticArrays
@@ -11,7 +12,7 @@ export Valkyrie,
 include("bipedcontrolutil.jl")
 using .BipedControlUtil
 
-packagepath() = Pkg.dir("ValkyrieRobot", "deps")
+packagepath() = joinpath(@__DIR__, "..", "deps")
 urdfpath() = joinpath(packagepath(), "valkyrie", "valkyrie.urdf")
 
 function default_contact_model()

--- a/src/bipedcontrolutil.jl
+++ b/src/bipedcontrolutil.jl
@@ -1,15 +1,17 @@
 # TODO: should probably be elsewhere
 module BipedControlUtil
-    export
-        Side,
-        left,
-        right,
-        flipsign_if_right
+using Compat.Random
 
-    # Side
-    # From https://bitbucket.org/ihmcrobotics/ihmc-open-robotics-software/src/575d33e1ab064f4e5957096414376fc011a98bce/IHMCRoboticsToolkit/src/us/ihmc/robotics/robotSide/RobotSide.java?at=develop&fileviewer=file-view-default
-    @enum Side left right
-    flipsign_if_right(x::Number, side::Side) = ifelse(side == right, -x, x)
-    Base.rand(rng::AbstractRNG, ::Type{Side}) = ifelse(rand(rng, Bool), left, right)
-    Base.:(-)(side::Side) = ifelse(side == right, left, right)
+export
+    Side,
+    left,
+    right,
+    flipsign_if_right
+
+# Side
+# From https://bitbucket.org/ihmcrobotics/ihmc-open-robotics-software/src/575d33e1ab064f4e5957096414376fc011a98bce/IHMCRoboticsToolkit/src/us/ihmc/robotics/robotSide/RobotSide.java?at=develop&fileviewer=file-view-default
+@enum Side left right
+flipsign_if_right(x::Number, side::Side) = ifelse(side == right, -x, x)
+Random.rand(rng::AbstractRNG, ::Type{Side}) = ifelse(rand(rng, Bool), left, right)
+Base.:(-)(side::Side) = ifelse(side == right, left, right)
 end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,1 @@
-RigidBodyTreeInspector 0.1.1
+MechanismGeometries 0.0.3

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using ValkyrieRobot
 using ValkyrieRobot.BipedControlUtil
-using RigidBodyTreeInspector
-using Base.Test
+using MechanismGeometries
+using Compat.Test
 
 @testset "side" begin
     @test -left == right
@@ -16,6 +16,7 @@ end
 
 @testset "load geometries" begin
     val = Valkyrie()
-    geometries = parse_urdf(ValkyrieRobot.urdfpath(), val.mechanism; package_path = [ValkyrieRobot.packagepath()]);
-    @test length(geometries) == 81
+    visuals = URDFVisuals(ValkyrieRobot.urdfpath(); package_path = [ValkyrieRobot.packagepath()])
+    meshgeometry = visual_elements(val.mechanism, visuals)
+    @test length(meshgeometry) == 81
 end


### PR DESCRIPTION
Also lose RigidBodyTreeInspector as a test dependency (use MechanismGeometries instead).