### PR TITLE
Use `Downloads.download` instead of `Base.download`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,21 +24,12 @@ jobs:
     env:
       PYTHON: ""
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ValkyrieRobot"
 uuid = "c74b26e8-f247-5d24-b013-c11a2bbd97c6"
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"

--- a/Project.toml
+++ b/Project.toml
@@ -3,18 +3,19 @@ uuid = "c74b26e8-f247-5d24-b013-c11a2bbd97c6"
 version = "0.2.1"
 
 [deps]
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RigidBodyDynamics = "366cf18f-59d5-5db9-a4de-86a9f6786172"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
+[compat]
+Downloads = "1"
+RigidBodyDynamics = "2"
+StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12, 1"
+julia = "1"
+
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[compat]
-RigidBodyDynamics = "2"
-julia = "1"
-StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12, 1"
-
 [targets]
 test = ["Test"]
-

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,3 +1,4 @@
+import Downloads
 datadir = "valkyrie"
 valkyrie_examples_url = "https://raw.githubusercontent.com/rdeits/drake/eb1dc0ff1b263772e26e177566479c9d17571e7d/examples/valkyrie/"
 urdfpath = "urdf/urdf/valkyrie_A_sim_drake_one_neck_dof_wide_ankle_rom.urdf"
@@ -63,11 +64,11 @@ meshpaths = ["urdf/model/meshes/arms/aj1_left.obj";
     "urdf/model/meshes/torso/torsoyaw.obj"]
 
 ispath(datadir) || mkpath(datadir)
-download(valkyrie_examples_url * urdfpath, joinpath(datadir, "valkyrie.urdf"))
+Downloads.download(valkyrie_examples_url * urdfpath, joinpath(datadir, "valkyrie.urdf"))
 
 for meshpath in meshpaths
     meshdir, meshfilename = splitdir(meshpath)
     meshdir = joinpath(datadir, meshdir)
     ispath(meshdir) || mkpath(meshdir)
-    download(valkyrie_examples_url * meshpath, joinpath(datadir, meshpath))
+    Downloads.download(valkyrie_examples_url * meshpath, joinpath(datadir, meshpath))
 end


### PR DESCRIPTION
Building ValkyrieRobot.jl fails on Julia 1.11 because of the now-deprecated `Base.download` (see [this thread](https://discourse.julialang.org/t/using-download-during-dep-build-julia-v1-11/121393)).

This is preventing CI jobs of packages that depend on ValkyrieRobot.jl from succeeding, e.g., MeshCatMechanisms.jl ([job link](https://github.com/JuliaRobotics/MeshCatMechanisms.jl/actions/runs/11738612461/job/32710061850)).

This PR fixes the issue.